### PR TITLE
fix: remove debug build from --version output

### DIFF
--- a/src/gflags_reporting.cc
+++ b/src/gflags_reporting.cc
@@ -353,9 +353,6 @@ static void ShowVersion() {
   } else {
     fprintf(stdout, "%s\n", ProgramInvocationShortName());
   }
-# if !defined(NDEBUG)
-  fprintf(stdout, "Debug build (NDEBUG not #defined)\n");
-# endif
 }
 
 static void AppendPrognameStrings(vector<string>* substrings,


### PR DESCRIPTION
Fixes `Debug build` being printed when using --version.

We always compile with asserts enabled (-UNDEBUG), so checking whether -NDEBUG is defined is not a reliable way of detecting whether it is a release or debug build for us.

This wasn't necessary in the CMake build because we set `-UNDEBUG` after creating the gflags targets.