### PR TITLE
restore "Debug Build" in  --version output

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -12,7 +12,7 @@ config_setting(
 )
 
 config_setting(
-    name = "gflags_debug_build",
+    name = "debug_build",
     values = {
         "compilation_mode": "dbg",
     },

--- a/BUILD
+++ b/BUILD
@@ -11,6 +11,13 @@ config_setting(
     values = {"cpu": "x64_windows"},
 )
 
+config_setting(
+    name = "gflags_debug_build",
+    values = {
+        "compilation_mode": "dbg",
+    },
+)
+
 load(":bazel/gflags.bzl", "gflags_sources", "gflags_library")
 
 (hdrs, srcs) = gflags_sources(namespace=["gflags", "google"])

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -470,6 +470,10 @@ foreach (TYPE IN ITEMS STATIC SHARED)
           VERSION     "${PACKAGE_VERSION}"
           SOVERSION   "${PACKAGE_SOVERSION}"
         )
+        target_compile_definitions(${target_name}
+          PRIVATE
+          $<$<CONFIG:Debug>:GFLAGS_DEBUG_BUILD>
+        )
         set (include_dirs "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>")
         if (INSTALL_HEADERS)
           list (APPEND include_dirs "$<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}>")

--- a/bazel/gflags.bzl
+++ b/bazel/gflags.bzl
@@ -92,12 +92,6 @@ def gflags_library(hdrs=[], srcs=[], threads=1):
     else:
         name += "_nothreads"
         copts += ["-DNO_THREADS"]
-    native.config_setting(
-        name = "gflags_debug_build",
-        values = {
-            "compilation_mode": "dbg",
-        },
-    )
     native.cc_library(
         name       = name,
         hdrs       = hdrs,
@@ -105,7 +99,7 @@ def gflags_library(hdrs=[], srcs=[], threads=1):
         copts      = copts,
         linkopts   = linkopts,
         defines    = select({
-            ":gflags_debug_build": ["GFLAGS_DEBUG_BUILD"],
+            "//:gflags_debug_build": ["GFLAGS_DEBUG_BUILD"],
             "//conditions:default": []
         }),
         visibility = ["//visibility:public"],

--- a/bazel/gflags.bzl
+++ b/bazel/gflags.bzl
@@ -103,5 +103,5 @@ def gflags_library(hdrs=[], srcs=[], threads=1):
             "//conditions:default": []
         }),
         visibility = ["//visibility:public"],
-        includes   = ['src']
+        include_prefix = 'gflags'
     )

--- a/bazel/gflags.bzl
+++ b/bazel/gflags.bzl
@@ -92,7 +92,7 @@ def gflags_library(hdrs=[], srcs=[], threads=1):
     else:
         name += "_nothreads"
         copts += ["-DNO_THREADS"]
-    config_setting(
+    native.config_setting(
         name = "gflags_debug_build",
         values = {
             "compilation_mode": "dbg",

--- a/bazel/gflags.bzl
+++ b/bazel/gflags.bzl
@@ -92,12 +92,22 @@ def gflags_library(hdrs=[], srcs=[], threads=1):
     else:
         name += "_nothreads"
         copts += ["-DNO_THREADS"]
+    config_setting(
+        name = "gflags_debug_build",
+        values = {
+            "compilation_mode": "dbg",
+        },
+    )
     native.cc_library(
         name       = name,
         hdrs       = hdrs,
         srcs       = srcs,
         copts      = copts,
         linkopts   = linkopts,
+        defines    = select({
+            ":gflags_debug_build": ["GFLAGS_DEBUG_BUILD"],
+            "//conditions:default": []
+        }),
         visibility = ["//visibility:public"],
-        include_prefix = 'gflags'
+        includes   = ['src']
     )

--- a/bazel/gflags.bzl
+++ b/bazel/gflags.bzl
@@ -99,7 +99,7 @@ def gflags_library(hdrs=[], srcs=[], threads=1):
         copts      = copts,
         linkopts   = linkopts,
         defines    = select({
-            "//:gflags_debug_build": ["GFLAGS_DEBUG_BUILD"],
+            "//:debug_build": ["GFLAGS_DEBUG_BUILD"],
             "//conditions:default": []
         }),
         visibility = ["//visibility:public"],

--- a/src/gflags_reporting.cc
+++ b/src/gflags_reporting.cc
@@ -353,6 +353,9 @@ static void ShowVersion() {
   } else {
     fprintf(stdout, "%s\n", ProgramInvocationShortName());
   }
+# if !defined(NDEBUG)
+  fprintf(stdout, "Debug build (NDEBUG not #defined)\n");
+# endif
 }
 
 static void AppendPrognameStrings(vector<string>* substrings,

--- a/src/gflags_reporting.cc
+++ b/src/gflags_reporting.cc
@@ -353,8 +353,8 @@ static void ShowVersion() {
   } else {
     fprintf(stdout, "%s\n", ProgramInvocationShortName());
   }
-# if !defined(NDEBUG)
-  fprintf(stdout, "Debug build (NDEBUG not #defined)\n");
+# ifdef GFLAGS_DEBUG_BUILD
+  fprintf(stdout, "Debug build\n");
 # endif
 }
 


### PR DESCRIPTION
Restores "Debug Build" print that we removed some time ago for technical reasons

# Testing
Bazel:
```
$ bazel run //integration/swiftlets_binary -c dbg --config=stamp  -- --version
swiftlets_binary version starling-v1.23.0-develop-2023062213
Debug build
```

CMake:
```
$ ./ppp_filter --version
ppp_filter
Debug build
```
