### PR TITLE
QNX fix

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,4 +4,5 @@ module(
     compatibility_level = 1,
 )
 
+bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_cc", version = "0.2.14")

--- a/bazel/gflags.bzl
+++ b/bazel/gflags.bzl
@@ -89,6 +89,8 @@ def gflags_library(hdrs=[], srcs=[], threads=1):
     if threads:
         linkopts += select({
             "//:x64_windows": [],
+            # pthreads is part of libc on QNX — no separate -lpthread needed
+            "@platforms//os:qnx": [],
             "//conditions:default": ["-lpthread"],
         })
     else:


### PR DESCRIPTION
pthreads is part of libc on QNX — no separate -lpthread needed